### PR TITLE
eeprom: Add support for get/set of vendor version

### DIFF
--- a/eeprom.c
+++ b/eeprom.c
@@ -27,7 +27,6 @@ static const char cfgblk_none[4] = "FFFF";
 #define CFGBLK_LENGTH	28
 static const char macfmt_tag[2] = "M1";
 static const uint8_t macaddr_placeholder[6] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
-#define MACFMT_VERSION  0
 struct module_eeprom_v1_raw {
 	uint16_t version;
 	uint16_t length; // no longer used
@@ -43,7 +42,7 @@ struct module_eeprom_v1_raw {
 	char     cfgblk_sig[4];
 	uint16_t cfgblk_len;
 	char     macfmt_tag[2];
-	uint16_t macfmt_version;
+	uint16_t vendor_version;
 	uint8_t  vendor_wifi_mac[6];
 	uint8_t  vendor_bt_mac[6];
 	uint8_t  vendor_ether_mac[6];
@@ -110,8 +109,6 @@ eeprom_data_valid (eeprom_context_t ctx)
 		if (memcmp(data->cfgblk_sig, cfgblk_sig, sizeof(cfgblk_sig)))
 			return 0;
 		if (memcmp(data->macfmt_tag, macfmt_tag, sizeof(macfmt_tag)))
-			return 0;
-		if (le16toh(data->macfmt_version) != MACFMT_VERSION)
 			return 0;
 	}
 	return 1;
@@ -285,6 +282,7 @@ eeprom_read (eeprom_context_t ctx, module_eeprom_t *data)
 	extract_macaddr(data->factory_default_bt_mac, rawdata->factory_default_bt_mac);
 	extract_macaddr(data->factory_default_wifi_alt_mac, rawdata->factory_default_wifi_alt_mac);
 	extract_macaddr(data->factory_default_ether_mac, rawdata->factory_default_ether_mac);
+	data->vendor_version = le16toh(rawdata->vendor_version);
 	extract_macaddr(data->vendor_wifi_mac, rawdata->vendor_wifi_mac);
 	extract_macaddr(data->vendor_bt_mac, rawdata->vendor_bt_mac);
 	extract_macaddr(data->vendor_ether_mac, rawdata->vendor_ether_mac);
@@ -324,7 +322,6 @@ eeprom_write (eeprom_context_t ctx, module_eeprom_t *data)
 			memcpy(rawdata->cfgblk_sig, cfgblk_sig, sizeof(rawdata->cfgblk_sig));
 			rawdata->cfgblk_len = CFGBLK_LENGTH;
 			memcpy(rawdata->macfmt_tag, macfmt_tag, sizeof(rawdata->macfmt_tag));
-			rawdata->macfmt_version = htole16(MACFMT_VERSION);
 		}
 	};
 
@@ -335,6 +332,7 @@ eeprom_write (eeprom_context_t ctx, module_eeprom_t *data)
 		strncpy(&rawdata->partnumber[1], data->partnumber, sizeof(rawdata->partnumber)-1);
 	}
 	strncpy(rawdata->asset_id, data->asset_id, sizeof(rawdata->asset_id));
+	rawdata->vendor_version = htole16(data->vendor_version);
 	if (ctx->mtype == module_type_cvm) {
 		extract_macaddr(rawdata->factory_default_wifi_mac, data->factory_default_wifi_mac);
 		extract_macaddr(rawdata->factory_default_bt_mac, data->factory_default_bt_mac);

--- a/eeprom.h
+++ b/eeprom.h
@@ -25,6 +25,7 @@ struct module_eeprom_s {
 	uint8_t  factory_default_wifi_alt_mac[6];
 	uint8_t  factory_default_ether_mac[6];
 	char     asset_id[15];
+	uint16_t vendor_version;
 	uint8_t  vendor_wifi_mac[6];
 	uint8_t  vendor_bt_mac[6];
 	uint8_t  vendor_ether_mac[6];

--- a/tegra-eeprom-tool.c
+++ b/tegra-eeprom-tool.c
@@ -46,6 +46,7 @@ static struct {
 	size_t length;
 	enum {
 		char_string,
+		hex_data,
 		mac_address,
 	} fieldtype;
 	int cvm_only;
@@ -56,6 +57,7 @@ static struct {
 	{ "factory-default-wifi-alt-mac", offsetof(module_eeprom_t, factory_default_wifi_alt_mac), 6, mac_address, 1 },
 	{ "factory-default-ether-mac", offsetof(module_eeprom_t, factory_default_ether_mac), 6, mac_address, 1 },
 	{ "asset-id", offsetof(module_eeprom_t, asset_id), 15, char_string },
+	{ "vendor-version", offsetof(module_eeprom_t, vendor_version), 1, hex_data },
 	{ "vendor-wifi-mac", offsetof(module_eeprom_t, vendor_wifi_mac), 6, mac_address, 1 },
 	{ "vendor-bt-mac", offsetof(module_eeprom_t, vendor_bt_mac), 6, mac_address, 1 },
 	{ "vendor-ether-mac", offsetof(module_eeprom_t, vendor_ether_mac), 6, mac_address, 1 },
@@ -113,6 +115,34 @@ hexdigit (int c) {
 }
 
 static ssize_t
+format_hexdata (char *buf, size_t bufsize, uint8_t *a)
+{
+	ssize_t n;
+	n = snprintf(buf, bufsize-1, "0x%02x%02x", a[0], a[1]);
+	if (n > 0)
+		*(buf + n) = '\0';
+
+	return n;
+
+} /* format_hexdata */
+
+static int
+parse_hexdata (uint8_t *a, const char *buf)
+{
+	const char *cp = buf;
+	int count = 0;
+
+	while (*cp != '\0' && count < 2) {
+		if (!isxdigit(*cp) || !isxdigit(*(cp+1)))
+			break;
+		a[count++] = (hexdigit(tolower(*cp)) << 4) | hexdigit(tolower(*(cp+1)));
+		cp += 2;
+	}
+	return (count == 2 && *cp == '\0') ? 0 : -1;
+
+} /* parse_hexdata */
+
+static ssize_t
 format_macaddr (char *buf, size_t bufsize, uint8_t *a)
 {
 	ssize_t n;
@@ -156,6 +186,9 @@ format_field (context_t ctx, int i, char *strbuf, size_t bufsize)
 			len = bufsize-1;
 		memcpy(strbuf, data + eeprom_fields[i].offset, len);
 		strbuf[len] = '\0';
+		break;
+	case hex_data:
+		len = format_hexdata(strbuf, bufsize, data + eeprom_fields[i].offset);
 		break;
 	case mac_address:
 		len = format_macaddr(strbuf, bufsize, data + eeprom_fields[i].offset);
@@ -301,6 +334,7 @@ do_set (context_t ctx, int argc, char * const argv[])
 {
 	int i, valindex;
 	uint8_t *data = (uint8_t *) &ctx->data;
+	uint8_t version[2];
 	uint8_t addr[6];
 	size_t len;
 
@@ -354,6 +388,13 @@ do_set (context_t ctx, int argc, char * const argv[])
 			*(data + eeprom_fields[i].offset + len) = '\0';
 			len += 1;
 		}
+		break;
+	case hex_data:
+		if (parse_hexdata(version, argv[valindex]) < 0) {
+			fprintf(stderr, "Error: could not parse hex data '%s'\n", argv[valindex]);
+			return 1;
+		}
+		memcpy(data + eeprom_fields[i].offset, version, sizeof(version));
 		break;
 	case mac_address:
 		if (parse_macaddr(addr, argv[valindex]) < 0) {


### PR DESCRIPTION
Bytes 158-159 are spec'd for customer overwritable version. Allow
getting and setting this version so it can be used in the future for
things like custom carrier board versions and revisions.