### PR TITLE
Use CMAKE_INSTALL_FULL_* for absolute paths

### DIFF
--- a/tegra-eeprom.pc.in
+++ b/tegra-eeprom.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/tegra-eeprom
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/tegra-eeprom
 
 Name: tegra-eeprom
 Version: @PROJECT_VERSION@


### PR DESCRIPTION
Instead of using a combination of CMAKE_INSTALL_PREFIX and CMAKE_INSTALL_, we should use CMAKE_INSTALL_FULL_.

If the CMAKE_INSTALL_ is an absolute path (e.g. in NixOS), then prefixing it with another absolute path would be incorrect. CMAKE_INSTALL_FULL_ already handles the case if
CMAKE_INSTALL_ is an absolute path. See:
https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

This almost identical to the change last year in: https://github.com/OE4T/tegra-boot-tools/pull/23