### PR TITLE
r36 updates

### DIFF
--- a/eeprom.c
+++ b/eeprom.c
@@ -287,11 +287,16 @@ eeprom_context_t
 eeprom_open (const char *pathname, eeprom_module_type_t mtype)
 {
 	int fd;
+	int readonly = 0;
 
 	fd = open(pathname, O_RDWR);
+	if (fd < 0) {
+		fd = open(pathname, O_RDONLY);
+		readonly = 1;
+	}
 	if (fd < 0)
 		return NULL;
-	return open_common(fd, mtype, 0, normal_read);
+	return open_common(fd, mtype, readonly, normal_read);
 
 } /* eeprom_open */
 

--- a/tegra-eeprom-tool.c
+++ b/tegra-eeprom-tool.c
@@ -54,7 +54,7 @@ static struct {
 	} moduletype;
 	uint8_t min_layout_version;
 } eeprom_fields[] = {
-	{ "major-version", offsetof(module_eeprom_t, major_version), sizeof(uint8_t), int_decimal, any_module_type, 1 },
+	{ "major-version", offsetof(module_eeprom_t, major_version), sizeof(uint8_t), int_decimal, any_module_type, 0 },
 	{ "minor-version", offsetof(module_eeprom_t, minor_version), sizeof(uint8_t), int_decimal, any_module_type, 1 },
 	{ "partnumber", offsetof(module_eeprom_t, partnumber), 22, char_string, any_module_type, 1 },
 	{ "factory-default-wifi-mac", offsetof(module_eeprom_t, factory_default_wifi_mac), 6, mac_address, cvm_only, 1 },


### PR DESCRIPTION
* Provide path to initialize blank eeprom
* Handle at24 eeprom marked 'read-only' in devicetree